### PR TITLE
request from nug: keep the scale of the axis between ships of the sam…

### DIFF
--- a/price_analysis_ocv.py
+++ b/price_analysis_ocv.py
@@ -290,7 +290,7 @@ def price_analysis(data_json): ## take json instead of png
     angle = 360 / num_categories
 
     # Maximum value for scaling
-    max_value = max(values)
+    max_value = sum(values)
 
     # Radius of the radar chart
     radius = min(center_x, center_y) - 150
@@ -298,7 +298,7 @@ def price_analysis(data_json): ## take json instead of png
     data_points = []
 
     for i in range(num_categories):
-        normalized_value = values[i] / max_value + 0.05
+        normalized_value = max(values[i] / max_value, 0.05)
         x = int(center_x + radius * normalized_value * math.cos(math.radians(i * angle)))
         y = int(center_y + radius * normalized_value * math.sin(math.radians(i * angle)))
 


### PR DESCRIPTION
…e price

nug said:

i dunno if its possible and i know features like this can be kinda difficult to add but it would be cool if you could compare two ships statistics easier. i think the way its set up now whatever stat is the highest is just set to the furthest point on the graph but if we could keep the axes static and overlay them we could compare similar designs. i think its helpful to have a tangible picture showing how saris spend less on thrust and more on armor for example, but the graph just looks like he spent more money in total than i did

I'm not sure if the graph will look good after the changes, but i think it will be fine.

Also, I changed the line to max() instead of add 0.05 because that way it only applies that when that statistic is less than 0.05.



